### PR TITLE
Use double setImmediate for the ICE gatherer

### DIFF
--- a/lib/RTCPeerConnection.js
+++ b/lib/RTCPeerConnection.js
@@ -64,7 +64,11 @@ function RTCPeerConnection(config) {
 	setIceConnectionState.call(this, RTCIceConnectionState.new);
 
 	// Run the ICE gatherer.
-	runIceGatherer.call(this);
+	// Use double setImmediate to prevent "icecandidate" being fired
+	// before setLocalDescription.
+	setImmediate(function() {
+		runIceGatherer.call(this);
+	}.bind(this))
 }
 
 


### PR DESCRIPTION
Use double setImmediate for the ICE gatherer to prevent "icecandidate" being fired before setLocalDescription.

This is not an ideal solution, but works well for our unit tests for sipjs. IMO the library should handle this in a async-safe way. On the other hand, setImmediate is sth far different than a network IO.
